### PR TITLE
Fix IOS-1116: 	IOS: Pictures/Icons in native tips/modals/carousels

### DIFF
--- a/Example_DynamicFramework/PointziDemo/Supporting Files/Info.plist
+++ b/Example_DynamicFramework/PointziDemo/Supporting Files/Info.plist
@@ -27,7 +27,7 @@
 			<string>demo</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>shtooltip</string>
+				<string>PZDynamic</string>
 			</array>
 		</dict>
 	</array>
@@ -35,6 +35,11 @@
 	<string>IOS1121_GitVersion-e1d7a67b-Wed Sep 20 14:34:28 CST 2017</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/Example_StaticLibrary/PointziDemo/Supporting Files/Info.plist
+++ b/Example_StaticLibrary/PointziDemo/Supporting Files/Info.plist
@@ -27,7 +27,7 @@
 			<string>demo</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>shtooltip</string>
+				<string>PZStatic</string>
 			</array>
 		</dict>
 	</array>
@@ -35,6 +35,11 @@
 	<string>IOS1121_GitVersion-e1d7a67b-Wed Sep 20 14:34:28 CST 2017</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>


### PR DESCRIPTION
Fix test App’s ATS which prevent image to be downloaded.