### PR TITLE
Fix IOS-1226:  IOS only shows one line content, hiding the rest as “……

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -37,8 +37,8 @@ pushd .
 
 cd Example_StaticLibrary
 
-# install third-party pods
-pod install
+# install/update third-party pods
+pod update
 
 # clean project
 xcodebuild clean -workspace PointziDemo.xcworkspace -scheme PointziDemo -sdk iphoneos -configuration Release
@@ -54,8 +54,8 @@ pushd .
 
 cd Example_DynamicFramework
 
-# install third-party pods
-pod install
+# install/update third-party pods
+pod update
 
 # clean project
 xcodebuild clean -workspace PointziDemo.xcworkspace -scheme PointziDemo -sdk iphoneos -configuration Release


### PR DESCRIPTION
…” which is different from dashboard

Must use “pod update” to make paper-onboarding-pointzi pod get updated. “pod install” doesn’t work for non-local pod.