### PR TITLE
Fix IOS-1247: CI: unlock keychain

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -33,6 +33,8 @@ echo "Build Pointzi demos"
 
 export PATH="$HOME/.fastlane/bin:$PATH"
 
+security unlock-keychain $BUILD_PASSWORD
+
 # ------------------- build PZStatic ------------------------
 
 pushd .


### PR DESCRIPTION
Unlock keychain before xcodebuild archive.