### PR TITLE
Fix IOS-1247: CI: unlock keychain

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -33,7 +33,7 @@ echo "Build Pointzi demos"
 
 export PATH="$HOME/.fastlane/bin:$PATH"
 
-security unlock-keychain $BUILD_PASSWORD
+security unlock-keychain -p $BUILD_PASSWORD "/Users/hawk/Library/Keychains/login.keychain-db"
 
 # ------------------- build PZStatic ------------------------
 

--- a/build.sh
+++ b/build.sh
@@ -33,8 +33,6 @@ echo "Build Pointzi demos"
 
 export PATH="$HOME/.fastlane/bin:$PATH"
 
-security unlock-keychain -p $BUILD_PASSWORD "/Users/hawk/Library/Keychains/login.keychain-db"
-
 # ------------------- build PZStatic ------------------------
 
 pushd .


### PR DESCRIPTION
Unlock keychain before xcodebuild archive.