### PR TITLE
Fix IOS-1247: CI: unlock keychain

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -33,6 +33,8 @@ echo "Build Pointzi demos"
 
 export PATH="$HOME/.fastlane/bin:$PATH"
 
+security unlock-keychain -p $BUILD_PASSWORD "/Users/hawk/Library/Keychains/login.keychain-db"
+
 # ------------------- build PZStatic ------------------------
 
 pushd .


### PR DESCRIPTION
Adding in salt doesn’t work. Change in build script again.