### PR TITLE
Fix IOS-1265: SVG lib generate with full bitcode

### DIFF
--- a/Example_DynamicFramework/PointziDemo.xcodeproj/project.pbxproj
+++ b/Example_DynamicFramework/PointziDemo.xcodeproj/project.pbxproj
@@ -679,7 +679,7 @@
 				ALTERNATE_GROUP = "";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = AG748WC3N7;
-				ENABLE_BITCODE = NO;
+				ENABLE_BITCODE = YES;
 				INFOPLIST_FILE = "PointziDemo/Supporting Files/Info.plist";
 				INSTALL_GROUP = "";
 				INSTALL_OWNER = "";
@@ -703,7 +703,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				DEVELOPMENT_TEAM = AG748WC3N7;
-				ENABLE_BITCODE = NO;
+				ENABLE_BITCODE = YES;
 				INFOPLIST_FILE = "PointziDemo/Supporting Files/Info.plist";
 				INSTALL_GROUP = "";
 				INSTALL_OWNER = "";

--- a/Example_StaticLibrary/PointziDemo.xcodeproj/project.pbxproj
+++ b/Example_StaticLibrary/PointziDemo.xcodeproj/project.pbxproj
@@ -687,7 +687,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = AG748WC3N7;
-				ENABLE_BITCODE = NO;
+				ENABLE_BITCODE = YES;
 				INFOPLIST_FILE = "PointziDemo/Supporting Files/Info.plist";
 				INSTALL_GROUP = "";
 				INSTALL_OWNER = "";
@@ -712,7 +712,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				DEVELOPMENT_TEAM = AG748WC3N7;
-				ENABLE_BITCODE = NO;
+				ENABLE_BITCODE = YES;
 				INFOPLIST_FILE = "PointziDemo/Supporting Files/Info.plist";
 				INSTALL_GROUP = "";
 				INSTALL_OWNER = "";


### PR DESCRIPTION
Enable bitcode of Pointzi demo Apps, and the same build error of customer’s show up.